### PR TITLE
CD workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to Kubernetes
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - staging
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Restore kubeconfig
+      run: |
+        echo "${{ secrets.KUBECONFIG }}" | base64 -d > kubeconfig
+
+    - name: Set target namespace
+      id: env
+      run: |
+        case "${GITHUB_REF##*/}" in
+          main) ENV=production ;;
+          staging) ENV=staging ;;
+          dev) ENV=development ;;
+          *) ENV=development ;; # fallback
+        esac
+        echo "env=$ENV" >> "$GITHUB_OUTPUT"
+
+    - name: Deploy to Kubernetes
+      run: |
+        kubectl --kubeconfig kubeconfig apply -f k8s/${{ steps.env.outputs.env }}/


### PR DESCRIPTION
Closes #14
This pull request introduces a new GitHub Actions workflow for automated deployment to Kubernetes clusters. The workflow is triggered on pushes to the `main`, `dev`, and `staging` branches, as well as manually via the workflow dispatch feature. The deployment process uses a base64-encoded kubeconfig secret and dynamically selects the target environment based on the branch.

**CI/CD automation:**

* Added a new `.github/workflows/deploy.yml` file to automate Kubernetes deployments on pushes to key branches and on manual dispatch.
* The workflow decodes a base64-encoded kubeconfig from secrets and sets the target namespace/environment (`production`, `staging`, or `development`) based on the branch.
* Deploys Kubernetes manifests from the corresponding environment-specific directory using `kubectl apply`.