### PR TITLE
Change Dockerfile's to only copy binaries

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,10 @@
 FROM golang:1.22 AS builder
 WORKDIR /app
-RUN apt-get update
 COPY . .
 RUN go build -o .
 
 FROM debian:bookworm-slim
-
-COPY --from=builder . .
-
+COPY --from=builder /app/backend .
 WORKDIR /app
-
 EXPOSE 9000
-
 CMD ["./backend"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,11 @@
 FROM golang:1.22 AS builder
 WORKDIR /app
-RUN apt-get update
 COPY . .
 RUN go build -o .
 
 FROM debian:bookworm-slim
 
-COPY --from=builder . .
+COPY --from=builder /app/frontend .
 
 WORKDIR /app
 


### PR DESCRIPTION
Reduces the final image size by roughly a factor of 10.
Images only contain binaries now.