### PR TITLE
added run of docker compose file to test application + clean up

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,3 +40,10 @@ jobs:
       run: |
         IMAGE_NAME=ghcr.io/strikzie/slow-and-steady-wins-the-race:latest
         docker push $IMAGE_NAME
+
+    - name: Run Docker Compose for tests
+      run: docker compose -f docker-compose.yml up --build --abort-on-container-exit
+
+    - name: Cleanup
+      if: always()
+      run: docker compose -f docker-compose.yml down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,17 @@ services:
     networks:
       - connection
 
+  tester:
+    image: curlimages/curl:8.1.2
+    depends_on:      
+      - frontend
+    entrypoint: >
+      sh -c "
+        echo 'Waiting for frontend...';
+        sleep 5;
+        curl -f http://frontend:8080/healthz || exit 1"
+    networks:
+      - connection
+
 networks:
   connection:


### PR DESCRIPTION
This pull request updates the CI workflow to add automated integration testing using Docker Compose. After pushing the Docker image, the workflow now runs tests inside containers and ensures cleanup after the test run.

**CI workflow improvements:**

* Added a step to run Docker Compose with the `docker-compose.yml` file, building images and running tests in containers.
* Added a cleanup step to bring down Docker Compose services and remove volumes, ensuring a clean environment after tests complete.